### PR TITLE
fix index for shell points extraction in Structure.py

### DIFF
--- a/surfmap/tools/Structure.py
+++ b/surfmap/tools/Structure.py
@@ -250,7 +250,7 @@ def parsePDBParticule(filin, charge = 1, infile = False) :
     # parcoure le PDB   
     for line in lines :
         if (line[0:4] == "ATOM") or ((line[0:6] == "HETATM") and ( (line[17:20].strip() == "MET") or  (line[17:20].strip() == "MSE") )) :
-            numpart = line[7:11].strip()
+            numpart = line[4:11].strip()
             dPDB["partlist"].append(numpart)
             dPDB[numpart] = {}
             dPDB[numpart]["x"] = float(line[30:38])


### PR DESCRIPTION
During maps generating I noticed incorrect closest atom assignments for some shell points. After checking the issue I found that problem is not related to distance calculation itself, but with parsing shell point identifiers. The issue is located in `parsePDBParticule()` in `Structure.py`. Parser reads the shell point identifier using: `line[7:11]` In results, parser for values > 9999 reads only last 4 digits so different shell points may end up with the same index causing their coordinates to overwrite each other. This later leads to incorrect closest-atom calculations. 

Proposed fix: change ranges of parsing from `line[7:11]` to `line[4:11]`.

I tested this changes locally and it resolves problem.